### PR TITLE
feat: add habit list and completion routes

### DIFF
--- a/src/app/api/habits/complete/route.ts
+++ b/src/app/api/habits/complete/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+function getSupabaseClient(token: string) {
+    return createClient(supabaseUrl, supabaseKey, {
+        global: { headers: { Authorization: `Bearer ${token}` } },
+    });
+}
+
+export async function POST(req: Request) {
+    const token = req.headers.get('Authorization')?.replace('Bearer ', '');
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const supabase = getSupabaseClient(token);
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user)
+        return NextResponse.json({ error: authError?.message || 'Unauthorized' }, { status: 401 });
+
+    const { id, is_completed } = await req.json();
+    const { data, error } = await supabase
+        .from('habits')
+        .update({ is_completed })
+        .eq('id', id)
+        .select()
+        .single();
+    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+    return NextResponse.json({ ok: true, habit: data });
+}

--- a/src/app/api/habits/list/route.ts
+++ b/src/app/api/habits/list/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+function getSupabaseClient(token: string) {
+    return createClient(supabaseUrl, supabaseKey, {
+        global: { headers: { Authorization: `Bearer ${token}` } },
+    });
+}
+
+export async function GET(req: Request) {
+    const token = req.headers.get('Authorization')?.replace('Bearer ', '');
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const supabase = getSupabaseClient(token);
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user)
+        return NextResponse.json({ error: authError?.message || 'Unauthorized' }, { status: 401 });
+
+    const { data, error } = await supabase.from('habits').select('*').eq('user_id', user.id);
+    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+    return NextResponse.json({ habits: data });
+}


### PR DESCRIPTION
## Summary
- add `GET /api/habits/list` to fetch a user's habits using Supabase auth token
- add `POST /api/habits/complete` to update habit `is_completed`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a83e97e2248322bdc74e1cd6817b63