### PR TITLE
feat: centralize server-side Supabase client

### DIFF
--- a/src/app/api/habits/create/route.ts
+++ b/src/app/api/habits/create/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabase';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
 
 export async function POST(req: Request) {
+    const { supabase } = await createSupabaseServerClient(req);
     const { user_id, title, target_days_per_week = 3 } = await req.json();
-    const { data, error } = await supabase.from('habits')
-        .insert({ user_id, title, target_days_per_week }).select().single();
+    const { data, error } = await supabase
+        .from('habits')
+        .insert({ user_id, title, target_days_per_week })
+        .select()
+        .single();
 
     if (error) return NextResponse.json({ error: error.message }, { status: 400 });
     return NextResponse.json({ ok: true, habit: data });

--- a/src/app/api/habits/log/route.ts
+++ b/src/app/api/habits/log/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabase';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
 
 export async function POST(req: Request) {
+    const { supabase } = await createSupabaseServerClient(req);
     const { habit_id, date } = await req.json();
-    const { data, error } = await supabase.from('habit_logs')
-        .insert({ habit_id, date, completed: true }).select().single();
+    const { data, error } = await supabase
+        .from('habit_logs')
+        .insert({ habit_id, date, completed: true })
+        .select()
+        .single();
 
     if (error) return NextResponse.json({ error: error.message }, { status: 400 });
     return NextResponse.json({ ok: true, log: data });

--- a/src/app/api/wheel/save/route.ts
+++ b/src/app/api/wheel/save/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabase';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
 
 /** body: { user_id, day, scores: Array<{domain:string, score:number}> } */
 export async function POST(req: Request) {
+    const { supabase } = await createSupabaseServerClient(req);
     const { user_id, day, scores } = await req.json();
     const rows = scores.map((s: { domain: string; score: number }) => ({
         user_id,

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,0 +1,25 @@
+import { createClient } from '@supabase/supabase-js';
+
+export async function createSupabaseServerClient(req: Request) {
+    const authHeader = req.headers.get('Authorization');
+    const supabase = createClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        {
+            global: {
+                headers: {
+                    Authorization: authHeader ?? '',
+                },
+            },
+        }
+    );
+
+    let user = null;
+    if (authHeader) {
+        const token = authHeader.replace(/^Bearer\s+/i, '');
+        const { data } = await supabase.auth.getUser(token);
+        user = data.user;
+    }
+
+    return { supabase, user };
+}


### PR DESCRIPTION
## Summary
- add `createSupabaseServerClient` helper that injects Authorization header and returns the current user
- refactor habit and wheel API routes to use shared Supabase server client

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a83ea4fd708322b5203146228cbefa